### PR TITLE
Ensure one Fly machine stays warm

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,6 +10,7 @@ internal_port  = 8080
 protocol       = "tcp"
 auto_stop_machines = true
 auto_start_machines = true
+min_machines_running = 1
 
 [[services.ports]]
   port     = 80


### PR DESCRIPTION
## Summary
- configure Fly deployment to keep at least one machine running for lower latency warmups

## Testing
- not applicable