### PR TITLE
Fix tool schema additionalProperties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,9 +2319,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.19.tgz",
-      "integrity": "sha512-V1r4wFdjaZIUIZZrV2Mb/prEeu03xvSm6oatPxsvnXKF9lNh5Jtk9QvUdiVfD9rrvi7bXrAVhg9Wpbmv/2Fl1g==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.20.tgz",
+      "integrity": "sha512-w6REE95NkGhQH/baA0reb6IQjVzSy5HOz9bZnRTFgOv+a1ZDo4p6yVs4McpFOZJeu810DSHayO3mwBsBXxZcaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -2337,16 +2337,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.13.19",
-        "@swc/core-darwin-x64": "1.13.19",
-        "@swc/core-linux-arm-gnueabihf": "1.13.19",
-        "@swc/core-linux-arm64-gnu": "1.13.19",
-        "@swc/core-linux-arm64-musl": "1.13.19",
-        "@swc/core-linux-x64-gnu": "1.13.19",
-        "@swc/core-linux-x64-musl": "1.13.19",
-        "@swc/core-win32-arm64-msvc": "1.13.19",
-        "@swc/core-win32-ia32-msvc": "1.13.19",
-        "@swc/core-win32-x64-msvc": "1.13.19"
+        "@swc/core-darwin-arm64": "1.13.20",
+        "@swc/core-darwin-x64": "1.13.20",
+        "@swc/core-linux-arm-gnueabihf": "1.13.20",
+        "@swc/core-linux-arm64-gnu": "1.13.20",
+        "@swc/core-linux-arm64-musl": "1.13.20",
+        "@swc/core-linux-x64-gnu": "1.13.20",
+        "@swc/core-linux-x64-musl": "1.13.20",
+        "@swc/core-win32-arm64-msvc": "1.13.20",
+        "@swc/core-win32-ia32-msvc": "1.13.20",
+        "@swc/core-win32-x64-msvc": "1.13.20"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.19.tgz",
-      "integrity": "sha512-NxDyte9tCJSJ8+R62WDtqwg8eI57lubD52sHyGOfezpJBOPr36bUSGGLyO3Vod9zTGlOu2CpkuzA/2iVw92u1g==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.20.tgz",
+      "integrity": "sha512-k/nqRwm6G3tw1BbCDxc3KmAMGsuDYA5Uh4MjYm23e+UziLyHz0z7W0zja3el+yGBIZXKlgSzWVFLsFDFzVqtgg==",
       "cpu": [
         "arm64"
       ],
@@ -2375,9 +2375,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.19.tgz",
-      "integrity": "sha512-+w5DYrJndSygFFRDcuPYmx5BljD6oYnAohZ15K1L6SfORHp/BTSIbgSFRKPoyhjuIkDiq3W0um8RoMTOBAcQjQ==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.20.tgz",
+      "integrity": "sha512-7xr+ACdUMNyrN87oEF1GvJIZJBAhGolfQVB0EYP08JEy8VSh//FEwfdlUz8gweaZyjOl1nuPS6ncXlKgZuZU8A==",
       "cpu": [
         "x64"
       ],
@@ -2392,9 +2392,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.19.tgz",
-      "integrity": "sha512-7LlfgpdwwYq2q7himNkAAFo4q6jysMLFNoBH6GRP7WL29NcSsl5mPMJjmYZymK+sYq/9MTVieDTQvChzYDsapw==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.20.tgz",
+      "integrity": "sha512-IaOLxU1U/oGV3lZ2T8tD5nB/5O60UFPqj5ZxYzDpCBVB73tDQDIxiDcro1X81nHbwJHjuHmbIrhoflS7LQN6+A==",
       "cpu": [
         "arm"
       ],
@@ -2409,9 +2409,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.19.tgz",
-      "integrity": "sha512-ml3I6Lm2marAQ3UC/TS9t/yILBh/eDSVHAdPpikp652xouWAVW1znUeV6bBSxe1sSZIenv+p55ubKAWq/u84sQ==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.20.tgz",
+      "integrity": "sha512-Lg6FyotDydXGnNnlw+u7vCZzR2+fX3Q2HiULBTYl2dey3TvRyzAfEhdgMjUc4beRzf26U9rzMuTroJ6KMBCBjA==",
       "cpu": [
         "arm64"
       ],
@@ -2426,9 +2426,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.19.tgz",
-      "integrity": "sha512-M/otFc3/rWWkbF6VgbOXVzUKVoE7MFcphTaStxJp4bwb7oP5slYlxMZN51Dk/OTOfvCDo9pTAFDKNyixbkXMDQ==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.20.tgz",
+      "integrity": "sha512-d1SvxmFykS0Ep8nPbduV1UwCvFjZ3ESzFKQdTbkr72bge8AseILBI9TbLTmoeWndDaTesiiTKRD5Y1iAvF1wvA==",
       "cpu": [
         "arm64"
       ],
@@ -2443,9 +2443,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.19.tgz",
-      "integrity": "sha512-NoMUKaOJEdouU4tKF88ggdDHFiRRING+gYLxDqnTfm+sUXaizB5OGBRzvSVDYSXQb1SuUuChnXFPFzwTWbt3ZQ==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.20.tgz",
+      "integrity": "sha512-Bwmng57EuMod58Q8GDJA8rmUgFl20taK8w8MqeeDMiCnZY2+rJrNERbIX3sXZbwsf/kCIELZ7q4ZXiwdyB4zoQ==",
       "cpu": [
         "x64"
       ],
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.19.tgz",
-      "integrity": "sha512-r6krlZwyu8SBaw24QuS1lau2I9q8M+eJV6ITz0rpb6P1Bx0elf9ii5Bhh8ddmIqXXH8kOGSjC/dwcdHbZqAhgw==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.20.tgz",
+      "integrity": "sha512-osCm3VEKL/OIKInyhy75S5B+R+QGBdpR1B5vwTYqG/1RB4vFM3O5SDtRZabd6NV9Cxc9dcLztWyZjhs2qp63SQ==",
       "cpu": [
         "x64"
       ],
@@ -2477,9 +2477,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.19.tgz",
-      "integrity": "sha512-awcZSIuxyVn0Dw28VjMvgk1qiDJ6CeQwHkZNUjg2UxVlq23zE01NMMp+zkoGFypmLG9gaGmJSzuoqvk/WCQ5tw==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.20.tgz",
+      "integrity": "sha512-svbQNirwEa6zwaAJPrEmQnMVZsOz8Jpr4nakFLkYIQwwJ73sBUkUJvH9ouIWmIu5bvgQrbQlRpxWTIY3e0Utlg==",
       "cpu": [
         "arm64"
       ],
@@ -2494,9 +2494,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.19.tgz",
-      "integrity": "sha512-H5d+KO7ISoLNgYvTbOcCQjJZNM3R7yaYlrMAF13lUr6GSiOUX+92xtM31B+HvzAWI7HtvVe74d29aC1b1TpXFA==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.20.tgz",
+      "integrity": "sha512-uVjjwGXJltUQK0v1qQSNGeMS6osLJuwgeTti5N7kxQ6mOfa1irxq+TX0YdIVQwIONMjzI+TP7lhqPeA9VdUjRg==",
       "cpu": [
         "ia32"
       ],
@@ -2511,9 +2511,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.13.19",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.19.tgz",
-      "integrity": "sha512-qNoyCpXvv2O3JqXKanRIeoMn03Fho/As+N4Fhe7u0FsYh4VYqGQah4DGDzEP/yjl4Gx1IElhqLGDhCCGMwWaDw==",
+      "version": "1.13.20",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.20.tgz",
+      "integrity": "sha512-Xm1JAew/P0TgsPSXyo60IH865fAmt9b2Mzd0FBJ77Q1xA1o/Oi9teCeGChyFq3+6JFao6uT0N4mcI3BJ4WBfkA==",
       "cpu": [
         "x64"
       ],
@@ -3697,9 +3697,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
-      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
+      "integrity": "sha512-be0PUaPsQX/gPWWgFsdD+GFzaoig5PXaUC1xLkQiYdDnANU8sMnHoQd8JhbJQuvTWrWLyeFN9Imb5Qtfvr4RrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4365,9 +4365,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
-      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
+      "version": "1.5.226",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.226.tgz",
+      "integrity": "sha512-0tS/r72Ze0WUBiDwnqw4X43TxA7gEuZg0kFwLthoCzkshIbNQFjkf6D8xEzBe6tY6Y65fUhZIuNedTugw+11Lw==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/tools/evaluations.ts
+++ b/src/tools/evaluations.ts
@@ -20,6 +20,7 @@ import {
   ResponseSchema,
   buildPromptResponsePair,
   type EvaluationPayloadInput,
+  LooseRecordSchema,
 } from './schemas.js';
 
 const DEFAULT_INCLUDE_CONTENT = false;
@@ -67,7 +68,7 @@ server.registerTool(
       prompt: PromptSchema.describe(D.prompt.root),
       response: ResponseSchema.describe(D.response.root),
       model_name: z.string().optional().describe(E.model_name),
-      properties: z.record(z.unknown()).optional().describe(S.properties),
+      properties: LooseRecordSchema.optional().describe(S.properties),
     },
   },
   async ({ metric_id, prompt, response, model_name, properties = {} }) => {
@@ -105,7 +106,7 @@ server.registerTool(
       prompt: PromptSchema.describe(D.prompt.root),
       response: ResponseSchema.describe(D.response.root),
       model_name: z.string().optional().describe(E.model_name),
-      properties: z.record(z.unknown()).optional().describe(S.properties),
+      properties: LooseRecordSchema.optional().describe(S.properties),
     },
   },
   async ({ metric_ids, prompt, response, model_name, properties = {} }) => {
@@ -194,7 +195,7 @@ server.registerTool(
     description: TOOL_DESCRIPTIONS.update_evaluation,
     inputSchema: {
       evaluation_id: z.string().describe(E.evaluation_id),
-      properties: z.record(z.unknown()).optional().describe(S.properties),
+      properties: LooseRecordSchema.optional().describe(S.properties),
     },
   },
   async ({ evaluation_id, properties }) => {

--- a/src/tools/metrics.ts
+++ b/src/tools/metrics.ts
@@ -9,6 +9,7 @@ import {
   SHARED_PARAM_DESCRIPTIONS as S,
   TOOL_DESCRIPTIONS,
 } from './descriptions.js';
+import { LooseRecordSchema } from './schemas.js';
 
 server.registerTool(
   'create_metric',
@@ -101,12 +102,9 @@ server.registerTool(
       skip: z.number().optional().describe(S.skip),
       limit: z.number().optional().describe(S.limit),
       tags: z.array(z.string()).optional().describe(M.tags),
-      filters: z
-        .record(z.any())
-        .optional()
-        .describe(
-          `${S.filters} Example: {"name": "foo"} to filter by exact name match.`
-        ),
+      filters: LooseRecordSchema.optional().describe(
+        `${S.filters} Example: {"name": "foo"} to filter by exact name match.`
+      ),
     },
   },
   async ({ skip, limit, tags, filters }) => {

--- a/src/tools/schemas.ts
+++ b/src/tools/schemas.ts
@@ -26,6 +26,10 @@ export type AssetKind = z.infer<typeof AssetKindSchema>;
 
 export type Metadata = Record<string, any>;
 
+// Allows arbitrary key/value pairs while serializing with additionalProperties: true.
+export const LooseRecordSchema = z.object({}).passthrough();
+export type LooseRecord = z.infer<typeof LooseRecordSchema>;
+
 export const ChatMessageSchema = z.object({
   role: RoleSchema.describe(D.chatMessage.role),
   content: z.string().describe(D.chatMessage.content),
@@ -36,7 +40,7 @@ const BaseAsset = {
   kind: AssetKindSchema,
   content: z.string(),
   description: z.string().optional(),
-  metadata: z.record(z.any()).optional(),
+  metadata: LooseRecordSchema.optional(),
 };
 
 export const ContextAssetSchema = z

--- a/tests/tool-schema-compat.test.ts
+++ b/tests/tool-schema-compat.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "@jest/globals";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import {
+  ContextAssetSchema,
+  LooseRecordSchema,
+  OutputAssetSchema,
+  PromptSchema,
+  ResponseSchema,
+} from "../src/tools/schemas.js";
+
+function collectAdditionalProperties(value: unknown, acc: unknown[] = []): unknown[] {
+  if (Array.isArray(value)) {
+    for (const entry of value) collectAdditionalProperties(entry, acc);
+    return acc;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === "additionalProperties") acc.push(entry);
+      collectAdditionalProperties(entry, acc);
+    }
+  }
+
+  return acc;
+}
+
+function gatherSchemaAdditionalProperties(schema: unknown): unknown[] {
+  return collectAdditionalProperties(schema, []);
+}
+
+describe("Tool schema JSON serialization", () => {
+  it("only emits boolean additionalProperties", () => {
+    const schemasToCheck = [
+      zodToJsonSchema(LooseRecordSchema),
+      zodToJsonSchema(ContextAssetSchema, { strictUnions: true }),
+      zodToJsonSchema(OutputAssetSchema, { strictUnions: true }),
+      zodToJsonSchema(PromptSchema, { strictUnions: true }),
+      zodToJsonSchema(ResponseSchema, { strictUnions: true }),
+    ];
+
+    for (const schema of schemasToCheck) {
+      const additions = gatherSchemaAdditionalProperties(schema);
+      for (const value of additions) {
+        expect(typeof value).toBe("boolean");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a passthrough loose record schema so JSON serialization emits boolean additionalProperties
- update tools to reuse the shared schema for properties filters metadata fields
- add regression test to ensure generated tool schemas never emit non-boolean additionalProperties

## Testing
- npm run build
- npm test -- --watchman=false